### PR TITLE
Audit owner-documented reexports

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -58,7 +58,7 @@ run_qa(
     reexports_allow = REEXPORTS,
     # The reexported names are documented by SciMLBase; they are not rendered in this
     # package's docs, which cover the ParallelParticleSwarms API only.
-    api_docs_kwargs = (; rendered_ignore = REEXPORTS),
+    api_docs_kwargs = (; ignore = REEXPORTS, rendered_ignore = REEXPORTS),
     # `NonlinearFunction` and `ImmutableNonlinearProblem` are extended in src/hybrid.jl to
     # keep the local solve isbits and allocation-free inside GPU kernels; treat them as
     # owned so Aqua does not flag the extensions as piracy.
@@ -94,6 +94,8 @@ run_qa(
 )
 
 @testset "Reexport surface" begin
+    @test Set(public_reexports(ParallelParticleSwarms)) == Set(REEXPORTS)
+
     # Every approved reexport must actually be reachable from `using
     # ParallelParticleSwarms`, so the allow-list cannot drift into approving names the
     # package no longer provides.


### PR DESCRIPTION
## Summary

- Mark all ParallelParticleSwarms compatibility reexports as both locally ignored and rendered-ignored, since their user-facing documentation is owned by the source packages.
- Add a generic public-API regression test requiring the reexport allowlist to match the package's live public reexports exactly.

## Verification

- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` -> `Quality Assurance | 20 20`, `Testing ParallelParticleSwarms tests passed`.
- `julia --project=docs docs/make.jl` completed successfully. Documenter emitted only the deployment auto-detection warning.
- `typos --diff -- .` and `git diff --check` passed.

The installed local `runic` binary is version 1.0.0 and does not provide a formatter/check command; this repository delegates the format check to its external reusable workflow, so no mechanical formatting sweep was applied.

Please ignore this PR until reviewed by @ChrisRackauckas.