### PR TITLE
docs: narrow public reexports and QA

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,3 +18,20 @@ BFGS
 PSOAlgorithm
 pso_solve
 ```
+
+## SciML Interface
+
+`ParallelParticleSwarms` provides the documented generic optimization entry points
+through its solver interface. Construct an `OptimizationProblem` and pass a
+`ParallelParticleSwarms` algorithm to `solve`.
+
+### `OptimizationProblem`
+
+Construct an optimization problem with an objective, initial point, and optional
+parameters or bounds. The full field and constructor documentation is maintained by
+SciMLBase in its [optimization interface documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/).
+
+### `solve`
+
+Pass the problem and one of the algorithms documented above to `solve`. The generic
+solver contract and keyword forwarding rules are defined by SciMLBase/CommonSolve.

--- a/src/ParallelParticleSwarms.jl
+++ b/src/ParallelParticleSwarms.jl
@@ -20,57 +20,8 @@ import PrecompileTools: @compile_workload, @setup_workload
 import QuasiMonteCarlo
 import QuasiMonteCarlo: LatinHypercubeSample, SamplingAlgorithm
 import SciMLBase
-import SciMLBase: ImmutableNonlinearProblem, NonlinearProblem, OptimizationFunction,
+import SciMLBase: ImmutableNonlinearProblem, NonlinearFunction, OptimizationFunction,
     OptimizationProblem, OptimizationStats, init, remake, reinit!, solve, solve!
-# The SciML common interface that ParallelParticleSwarms reexports (see the second
-# `export` below), so that `using ParallelParticleSwarms` keeps giving access to the
-# problem, function, solution and solve API it exposed when it reexported SciMLBase
-# wholesale. Each name is imported from the module that owns it: importing a
-# SciMLOperators name through SciMLBase's reexport leaves the binding unresolved
-# ("Imported binding ... was undeclared at import time" on Julia 1.12) and Aqua then
-# reports it as an undefined export.
-using SciMLBase: AbstractAnalyticalProblem, AnalyticalProblem, BVPFunction,
-    BVProblem, BatchIntegralFunction, CallbackSet, CheckInit, Clocks, ContinuousCallback,
-    ConvexOptimizationProblem, DAEFunction, DAEProblem, DAESolution, DDEFunction,
-    DDEProblem, DiscreteCallback, DiscreteFunction, DiscreteProblem, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalDDEProblem, DynamicalODEFunction, DynamicalODEProblem,
-    DynamicalSDEFunction, DynamicalSDEProblem, EigenvalueProblem, EigenvalueSolution,
-    EigenvalueTarget, EnsembleAnalysis, EnsembleContext, EnsembleDistributed,
-    EnsembleProblem, EnsembleSerial, EnsembleSolution, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleTestSolution, EnsembleThreads, HomotopyNonlinearFunction,
-    HomotopyProblem, ImplicitDiscreteFunction, ImplicitDiscreteProblem,
-    IncrementingODEFunction, IncrementingODEProblem, IntegralFunction, IntegralProblem,
-    IntegralSolution, IntervalNonlinearFunction, IntervalNonlinearProblem,
-    LinearAliasSpecifier, LinearProblem, LinearSolution, MultiObjectiveOptimizationFunction,
-    NoiseProblem, NonlinearFunction, NonlinearLeastSquaresProblem, NonlinearSolution,
-    ODEAliasSpecifier, ODEFunction, ODEInputFunction, ODEProblem, ODESolution,
-    OptimizationSolution, PDENoTimeSolution, PDEProblem, PDETimeSeriesSolution,
-    RODEFunction, RODEProblem, RODESolution, ReturnCode, SCCNonlinearProblem, SDDEFunction,
-    SDDEProblem, SDEFunction, SDEProblem, SampledIntegralProblem, SecondOrderBVProblem,
-    SecondOrderDDEProblem, SecondOrderODEProblem, SplitFunction, SplitODEProblem,
-    SplitSDEFunction, SplitSDEProblem, SteadyStateProblem, SteadyStateSolution, TimeDomain,
-    TwoPointBVPFunction, TwoPointBVProblem, TwoPointDynamicalBVPFunction,
-    TwoPointSecondOrderBVProblem, VectorContinuousCallback, add_saveat!, add_tstop!, addat!,
-    addat_non_user_cache!, addsteps!, auto_dt_reset!, change_t_via_interpolation!,
-    check_error, check_keywords, deleteat_non_user_cache!, derivative_discontinuity!,
-    discretize, du_cache, first_tstop, full_cache, get_dt, get_du, get_du!, get_proposed_dt,
-    get_rng, get_tmp_cache, has_rng, has_tstop, is_discrete_time_domain, isclock,
-    iscontinuous, isdiscrete, isinplace, issolverstepclock, pop_tstop!, rand_cache,
-    ratenoise_cache, reeval_internals_due_to_modification!, resize_non_user_cache!,
-    savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_rng!, set_t!, set_u!,
-    step!, supports_solve_rng, symbolic_discretize, terminate!, u_cache, u_modified!,
-    user_cache, warn_compat
-using SciMLOperators: AddVector, AffineOperator, BlockDiagonalOperator, DiagonalOperator,
-    FunctionOperator, IdentityOperator, InvertibleOperator, MatrixOperator, NullOperator,
-    ScalarOperator, SciMLOperators, StaticWOperator, TensorProductOperator,
-    TensorSumOperator, WOperator, cache_operator, concretize, has_adjoint,
-    has_concretization, has_exp, has_expmv, has_expmv!, has_ldiv, has_ldiv!, has_mul,
-    has_mul!, iscached, isconstant, isconvertible, islinear, issquare, kronsum,
-    update_coefficients, update_coefficients!
-using Base: deleteat!
-# `AllObserved` reaches SciMLBase from RecursiveArrayTools, so importing it through
-# SciMLBase leaves the binding unresolved the same way the SciMLOperators names do.
-using RecursiveArrayTools: AllObserved
 import Setfield: @set!
 import SimpleNonlinearSolve: SimpleBroyden, SimpleLimitedMemoryBroyden
 import StaticArrays
@@ -147,45 +98,5 @@ include("./precompilation.jl")
 
 export ParallelPSOKernel,
     ParallelSyncPSOKernel, ParallelPSOArray, SerialPSO, PSOAlgorithm, HybridPSO, LBFGS, BFGS,
-    pso_solve
-
-# Reexported SciML common interface; approved via `reexports_allow` in test/qa/qa.jl.
-export AbstractAnalyticalProblem, AddVector, AffineOperator, AllObserved, AnalyticalProblem,
-    BVPFunction, BVProblem, BatchIntegralFunction, BlockDiagonalOperator, CallbackSet,
-    CheckInit, Clocks, ContinuousCallback, ConvexOptimizationProblem, DAEFunction,
-    DAEProblem, DAESolution, DDEFunction, DDEProblem, DiagonalOperator, DiscreteCallback,
-    DiscreteFunction, DiscreteProblem, DynamicalBVPFunction, DynamicalDDEFunction,
-    DynamicalDDEProblem, DynamicalODEFunction, DynamicalODEProblem, DynamicalSDEFunction,
-    DynamicalSDEProblem, EigenvalueProblem, EigenvalueSolution, EigenvalueTarget,
-    EnsembleAnalysis, EnsembleContext, EnsembleDistributed, EnsembleProblem, EnsembleSerial,
-    EnsembleSolution, EnsembleSplitThreads, EnsembleSummary, EnsembleTestSolution,
-    EnsembleThreads, FunctionOperator, HomotopyNonlinearFunction, HomotopyProblem,
-    IdentityOperator, ImplicitDiscreteFunction, ImplicitDiscreteProblem,
-    IncrementingODEFunction, IncrementingODEProblem, IntegralFunction, IntegralProblem,
-    IntegralSolution, IntervalNonlinearFunction, IntervalNonlinearProblem,
-    InvertibleOperator, LinearAliasSpecifier, LinearProblem, LinearSolution, MatrixOperator,
-    MultiObjectiveOptimizationFunction, NoiseProblem, NonlinearFunction,
-    NonlinearLeastSquaresProblem, NonlinearProblem, NonlinearSolution, NullOperator,
-    ODEAliasSpecifier, ODEFunction, ODEInputFunction, ODEProblem, ODESolution,
-    OptimizationFunction, OptimizationProblem, OptimizationSolution, PDENoTimeSolution,
-    PDEProblem, PDETimeSeriesSolution, RODEFunction, RODEProblem, RODESolution, ReturnCode,
-    SCCNonlinearProblem, SDDEFunction, SDDEProblem, SDEFunction, SDEProblem,
-    SampledIntegralProblem, ScalarOperator, SciMLBase, SciMLOperators, SecondOrderBVProblem,
-    SecondOrderDDEProblem, SecondOrderODEProblem, SplitFunction, SplitODEProblem,
-    SplitSDEFunction, SplitSDEProblem, StaticWOperator, SteadyStateProblem,
-    SteadyStateSolution, TensorProductOperator, TensorSumOperator, TimeDomain,
-    TwoPointBVPFunction, TwoPointBVProblem, TwoPointDynamicalBVPFunction,
-    TwoPointSecondOrderBVProblem, VectorContinuousCallback, WOperator, add_saveat!,
-    add_tstop!, addat!, addat_non_user_cache!, addsteps!, auto_dt_reset!, cache_operator,
-    change_t_via_interpolation!, check_error, check_keywords, concretize, deleteat!,
-    deleteat_non_user_cache!, derivative_discontinuity!, discretize, du_cache, first_tstop,
-    full_cache, get_dt, get_du, get_du!, get_proposed_dt, get_rng, get_tmp_cache,
-    has_adjoint, has_concretization, has_exp, has_expmv, has_expmv!, has_ldiv, has_ldiv!,
-    has_mul, has_mul!, has_rng, has_tstop, init, is_discrete_time_domain, iscached, isclock,
-    isconstant, iscontinuous, isconvertible, isdiscrete, isinplace, islinear,
-    issolverstepclock, issquare, kronsum, pop_tstop!, rand_cache, ratenoise_cache,
-    reeval_internals_due_to_modification!, reinit!, remake, resize_non_user_cache!,
-    savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_rng!, set_t!, set_u!,
-    solve, solve!, step!, supports_solve_rng, symbolic_discretize, terminate!, u_cache,
-    u_modified!, update_coefficients, update_coefficients!, user_cache, warn_compat
+    OptimizationProblem, solve, pso_solve
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,6 +1,5 @@
 using ParallelParticleSwarms
 import ParallelParticleSwarms: PSOAlgorithm, pso_solve
-using SciMLBase
 using Test
 
 struct MockPSO <: PSOAlgorithm end
@@ -13,7 +12,7 @@ end
 
 @testset "PSOAlgorithm interface" begin
     prob = OptimizationProblem((u, _) -> sum(abs2, u), [1.0, -2.0], nothing)
-    sol = SciMLBase.solve(prob, MockPSO())
+    sol = solve(prob, MockPSO())
 
     @test sol.u == prob.u0
     @test sol.objective == 5.0

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,64 +1,11 @@
 using SciMLTesting, ParallelParticleSwarms, Test
 using JET
 
-# The SciMLBase common interface ParallelParticleSwarms deliberately reexports, so that
-# `using ParallelParticleSwarms` is enough to build an `OptimizationProblem` and `solve`
-# it. Owned and documented upstream by SciMLBase; kept in sync with the reexport
-# `export` block in src/ParallelParticleSwarms.jl.
-const REEXPORTS = (
-    :AbstractAnalyticalProblem, :AddVector, :AffineOperator, :AllObserved,
-    :AnalyticalProblem, :BVPFunction, :BVProblem, :BatchIntegralFunction,
-    :BlockDiagonalOperator, :CallbackSet, :CheckInit, :Clocks, :ContinuousCallback,
-    :ConvexOptimizationProblem, :DAEFunction, :DAEProblem, :DAESolution, :DDEFunction,
-    :DDEProblem, :DiagonalOperator, :DiscreteCallback, :DiscreteFunction, :DiscreteProblem,
-    :DynamicalBVPFunction, :DynamicalDDEFunction, :DynamicalDDEProblem,
-    :DynamicalODEFunction, :DynamicalODEProblem, :DynamicalSDEFunction,
-    :DynamicalSDEProblem, :EigenvalueProblem, :EigenvalueSolution, :EigenvalueTarget,
-    :EnsembleAnalysis, :EnsembleContext, :EnsembleDistributed, :EnsembleProblem,
-    :EnsembleSerial, :EnsembleSolution, :EnsembleSplitThreads, :EnsembleSummary,
-    :EnsembleTestSolution, :EnsembleThreads, :FunctionOperator, :HomotopyNonlinearFunction,
-    :HomotopyProblem, :IdentityOperator, :ImplicitDiscreteFunction,
-    :ImplicitDiscreteProblem, :IncrementingODEFunction, :IncrementingODEProblem,
-    :IntegralFunction, :IntegralProblem, :IntegralSolution, :IntervalNonlinearFunction,
-    :IntervalNonlinearProblem, :InvertibleOperator, :LinearAliasSpecifier, :LinearProblem,
-    :LinearSolution, :MatrixOperator, :MultiObjectiveOptimizationFunction, :NoiseProblem,
-    :NonlinearFunction, :NonlinearLeastSquaresProblem, :NonlinearProblem,
-    :NonlinearSolution, :NullOperator, :ODEAliasSpecifier, :ODEFunction, :ODEInputFunction,
-    :ODEProblem, :ODESolution, :OptimizationFunction, :OptimizationProblem,
-    :OptimizationSolution, :PDENoTimeSolution, :PDEProblem, :PDETimeSeriesSolution,
-    :RODEFunction, :RODEProblem, :RODESolution, :ReturnCode, :SCCNonlinearProblem,
-    :SDDEFunction, :SDDEProblem, :SDEFunction, :SDEProblem, :SampledIntegralProblem,
-    :ScalarOperator, :SciMLBase, :SciMLOperators, :SecondOrderBVProblem,
-    :SecondOrderDDEProblem, :SecondOrderODEProblem, :SplitFunction, :SplitODEProblem,
-    :SplitSDEFunction, :SplitSDEProblem, :StaticWOperator, :SteadyStateProblem,
-    :SteadyStateSolution, :TensorProductOperator, :TensorSumOperator, :TimeDomain,
-    :TwoPointBVPFunction, :TwoPointBVProblem, :TwoPointDynamicalBVPFunction,
-    :TwoPointSecondOrderBVProblem, :VectorContinuousCallback, :WOperator, :add_saveat!,
-    :add_tstop!, :addat!, :addat_non_user_cache!, :addsteps!, :auto_dt_reset!,
-    :cache_operator, :change_t_via_interpolation!, :check_error, :check_keywords,
-    :concretize, :deleteat!, :deleteat_non_user_cache!, :derivative_discontinuity!,
-    :discretize, :du_cache, :first_tstop, :full_cache, :get_dt, :get_du, :get_du!,
-    :get_proposed_dt, :get_rng, :get_tmp_cache, :has_adjoint, :has_concretization, :has_exp,
-    :has_expmv, :has_expmv!, :has_ldiv, :has_ldiv!, :has_mul, :has_mul!, :has_rng,
-    :has_tstop, :init, :is_discrete_time_domain, :iscached, :isclock, :isconstant,
-    :iscontinuous, :isconvertible, :isdiscrete, :isinplace, :islinear, :issolverstepclock,
-    :issquare, :kronsum, :pop_tstop!, :rand_cache, :ratenoise_cache,
-    :reeval_internals_due_to_modification!, :reinit!, :remake, :resize_non_user_cache!,
-    :savevalues!, :set_abstol!, :set_proposed_dt!, :set_reltol!, :set_rng!, :set_t!,
-    :set_u!, :solve, :solve!, :step!, :supports_solve_rng, :symbolic_discretize,
-    :terminate!, :u_cache, :u_modified!, :update_coefficients, :update_coefficients!,
-    :user_cache, :warn_compat,
-)
+const REEXPORTS = (:OptimizationProblem, :solve)
 
-# The ignore lists below cover names this package genuinely needs but whose owners have
-# not declared them public. Each entry names the owner and, where a fix is in flight, the
-# upstream PR; when one merges, drop the entry rather than working around the name.
 run_qa(
     ParallelParticleSwarms;
     reexports_allow = REEXPORTS,
-    # The reexported names are documented by SciMLBase; they are not rendered in this
-    # package's docs, which cover the ParallelParticleSwarms API only.
-    api_docs_kwargs = (; ignore = REEXPORTS, rendered_ignore = REEXPORTS),
     # `NonlinearFunction` and `ImmutableNonlinearProblem` are extended in src/hybrid.jl to
     # keep the local solve isbits and allocation-free inside GPU kernels; treat them as
     # owned so Aqua does not flag the extensions as piracy.


### PR DESCRIPTION
## What changed

ParallelParticleSwarms previously reexported the entire SciMLBase surface inherited from its historical `@reexport using SciMLBase`. The documented package-facing workflow uses only `OptimizationProblem` and `solve`, so this PR removes the blanket reexports and keeps those two explicit, documented generic entry points.

The QA allowlist now covers only those two reexports. The interface test exercises `OptimizationProblem` and `solve` through `using ParallelParticleSwarms` without importing SciMLBase. The docs add a package-facing SciML interface section and link the owner documentation for the problem contract.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

- `PPS_TEST_GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
  - `QA | 26 | 26 | 1m57.1s`
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); include("docs/make.jl")'` initially exposed the invalid clone remote; after configuring the local `origin`, the exact docs build command `julia --startup-file=no --project=docs docs/make.jl` completed with exit code 0.
- `julia --startup-file=no -m Runic --check src/ParallelParticleSwarms.jl test/interface.jl test/qa/qa.jl docs/make.jl`: exit 0
- `typos --force-exclude docs/src/index.md docs/make.jl src/ParallelParticleSwarms.jl test/interface.jl test/qa/qa.jl`: exit 0
- `git diff --check`: exit 0
- Direct package load and reexport assertion: passed; exported generic reexports are exactly `[:OptimizationProblem, :solve]`.

No hosted CI was used as verification.
