### PR TITLE
Restore the optimization cache interface on `using ParallelParticleSwarms`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,19 +22,44 @@ PSOAlgorithm
 pso_solve
 ```
 
-## SciML Interface
+## Reexported SciML common interface
 
-`ParallelParticleSwarms` provides the documented generic optimization entry points
-through its solver interface. Construct an `OptimizationProblem` and pass a
-`ParallelParticleSwarms` algorithm to `solve`.
+`using ParallelParticleSwarms` also brings in the parts of the SciML common
+optimization interface needed to build a problem, solve it and inspect the result, so
+they do not have to be imported separately. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/) -- ParallelParticleSwarms only
+re-exports them:
 
-### `OptimizationProblem`
+  - Problems and functions:
+    [`OptimizationProblem`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/),
+    [`OptimizationFunction`](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/),
+    `NullParameters`
+  - Solutions: [`OptimizationSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/),
+    `OptimizationStats`
+  - Solving: [`solve`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Common_Keywords/),
+    `init`, `solve!`, `reinit!`, `remake`
+  - Return status: `ReturnCode`, `successful_retcode`
 
-Construct an optimization problem with an objective, initial point, and optional
-parameters or bounds. The full field and constructor documentation is maintained by
-SciMLBase in its [optimization interface documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/).
+`SimpleLBFGS`, the local polish algorithm [`HybridPSO`](@ref) accepts, is re-exported
+from [SimpleOptimization.jl](https://docs.sciml.ai/Optimization/stable/optimization_packages/simpleoptimization/).
 
-### `solve`
+The usual workflow is either a single `solve` call:
 
-Pass the problem and one of the algorithms documented above to `solve`. The generic
-solver contract and keyword forwarding rules are defined by SciMLBase/CommonSolve.
+```julia
+prob = OptimizationProblem(OptimizationFunction{false}(f), u0, p; lb = lb, ub = ub)
+sol = solve(prob, ParallelSyncPSOKernel(1000; backend = CPU()); maxiters = 500)
+```
+
+or the cache workflow, which lets the same swarm be re-run against updated bounds or
+parameters:
+
+```julia
+cache = init(prob, ParallelPSOKernel(1000; backend = CPU()))
+sol = solve!(cache; maxiters = 500)
+reinit!(cache)
+```
+
+Anything else from SciMLBase -- the ODE/SDE/DAE/nonlinear problem classes, the
+integrator interface, the SciML operators -- is not re-exported here, because
+ParallelParticleSwarms does not solve those problems; import it from SciMLBase
+directly.

--- a/src/ParallelParticleSwarms.jl
+++ b/src/ParallelParticleSwarms.jl
@@ -22,6 +22,12 @@ import QuasiMonteCarlo: LatinHypercubeSample, SamplingAlgorithm
 import SciMLBase
 import SciMLBase: ImmutableNonlinearProblem, NonlinearFunction, OptimizationFunction,
     OptimizationProblem, OptimizationStats, init, remake, reinit!, solve, solve!
+# The rest of the SciML common optimization interface that ParallelParticleSwarms
+# reexports (see the second `export` below), so that `using ParallelParticleSwarms` on
+# its own is enough to build an `OptimizationProblem`, run the
+# `init`/`reinit!`/`solve!` cache workflow, and inspect the result. Everything stays
+# owned and documented upstream in SciMLBase.
+import SciMLBase: NullParameters, OptimizationSolution, ReturnCode, successful_retcode
 import Setfield: @set!
 import SimpleNonlinearSolve: SimpleBroyden
 import SimpleOptimization
@@ -101,5 +107,11 @@ include("./precompilation.jl")
 
 export ParallelPSOKernel,
     ParallelSyncPSOKernel, ParallelPSOArray, SerialPSO, PSOAlgorithm, HybridPSO,
-    SimpleLBFGS, BFGS, OptimizationProblem, solve, pso_solve
+    SimpleLBFGS, BFGS, pso_solve
+
+# Reexported SciML common optimization interface; approved via `reexports_allow` in
+# test/qa/qa.jl.
+export NullParameters, OptimizationFunction, OptimizationProblem, OptimizationSolution,
+    OptimizationStats, ReturnCode, init, reinit!, remake, solve, solve!,
+    successful_retcode
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,17 @@
 using SciMLTesting, ParallelParticleSwarms, Test
 using JET
 
-const REEXPORTS = (:OptimizationProblem, :SimpleLBFGS, :solve)
+# The SciML common optimization interface ParallelParticleSwarms deliberately reexports
+# so that `using ParallelParticleSwarms` is enough to build a problem, solve it (either
+# directly or through the `init`/`reinit!`/`solve!` cache workflow) and inspect the
+# result. Owned and documented upstream; kept in sync with the reexport `export` block
+# in src/ParallelParticleSwarms.jl. `SimpleLBFGS` is the SimpleOptimization local
+# algorithm `HybridPSO` takes.
+const REEXPORTS = (
+    :NullParameters, :OptimizationFunction, :OptimizationProblem, :OptimizationSolution,
+    :OptimizationStats, :ReturnCode, :SimpleLBFGS, :init, :reinit!, :remake, :solve,
+    :solve!, :successful_retcode,
+)
 
 run_qa(
     ParallelParticleSwarms;


### PR DESCRIPTION
## What broke

`66e277f` ("Migrate QA to SciMLTesting 2.4", #116) removed
`@reexport using SciMLBase`. That commit then restored all 185 SciMLBase names as
explicit exports, and `b27522a` ("docs: narrow public reexports and QA", #123)
narrowed the list to three:

```julia
const REEXPORTS = (:OptimizationProblem, :SimpleLBFGS, :solve)
```

Dropping the bulk of SciMLBase was correct -- this package does not solve ODEs,
SDEs, DAEs or nonlinear systems, and had no business exporting their problem
types. But the narrowing also removed the rest of the interface a
ParallelParticleSwarms user actually calls.

## Evidence used to pick the restored names

1. **The package implements them.** `SciMLBase.init` (src/init.jl:56, :88, :143),
   `SciMLBase.solve!` (src/solve.jl:5, :11, :36 and src/hybrid.jl:47, :100) and
   `SciMLBase.reinit!` (src/init.jl:117) are ParallelParticleSwarms methods. The
   `init` / `reinit!` / `solve!` cache workflow is a feature of this package, and
   none of its three entry points was reachable from `using ParallelParticleSwarms`.
2. **The repo's own examples need `OptimizationFunction`.** Every problem built in
   `test/` uses `OptimizationFunction{false}(f, ...)` -- the out-of-place form is
   mandatory for the `SVector` objectives this package is built around, since
   `OptimizationProblem(f, u0, p)` infers the in-place form and errors with
   *"Initial condition incompatible with functional form"*. `test/reinit.jl`,
   `test/constraints.jl`, `test/regression.jl` and `test/gpu.jl` all obtain it via
   an explicit `using SciMLBase`, which is what kept CI green while the public
   surface was broken.
3. **`names(ParallelParticleSwarms)` vs `names(SciMLBase)`** to confirm what was
   actually lost, and to confirm what was *not*: `AutoForwardDiff` / `AutoEnzyme`
   are ADTypes names that SciMLBase never exported, so they were never part of this
   package's surface and are deliberately not added here.

## Restored names

```
NullParameters, OptimizationFunction, OptimizationProblem, OptimizationSolution,
OptimizationStats, ReturnCode, init, reinit!, remake, solve, solve!,
successful_retcode
```

`SimpleLBFGS` (from SimpleOptimization) is unchanged. Everything else from
SciMLBase -- the other equation classes, the integrator interface, SciMLOperators
-- stays out, and the docs say so explicitly.

`names(ParallelParticleSwarms)` goes from 12 to 22.

## Documentation

`docs/src/index.md` gains a **Reexported SciML common interface** section that
lists the names grouped by role (problems and functions / solutions / solving /
return status), links each group to the owning SciMLBase documentation, shows both
the single-`solve` and the `init`/`solve!`/`reinit!` cache workflows, and closes
with the explicit boundary line. The docs list, the `export` block in
`src/ParallelParticleSwarms.jl` and the `REEXPORTS` tuple in `test/qa/qa.jl` are
the same list in three places.

## Why this is not breaking

Every name here was exported by `using ParallelParticleSwarms` before `66e277f`.
Restoring previously-exported names is additive. No version bump is included; the
release pass handles versions.

## What was verified (run, not just inspected)

- `test/qa/qa.jl` runs clean locally: **Quality Assurance 21/21 pass** (Aqua,
  ExplicitImports including `all_explicit_imports_are_public`, the public-API
  documentation check and `No unapproved public reexports`) and the
  **Reexport surface testset 27/27 pass**.
- A documented end-to-end workflow runs from a bare
  `using ParallelParticleSwarms, StaticArrays, KernelAbstractions`:
  `OptimizationFunction{false}` + `OptimizationProblem` + `solve(..., SerialPSO)`
  reaching objective `3.8e-7`, then `init` + `reinit!` + `solve!` on
  `ParallelPSOKernel`, plus `remake` and `successful_retcode`.
- `names(ParallelParticleSwarms)` contains all twelve restored names.
- Runic reports no formatting changes for the touched Julia files.
- The GPU test groups were **not** run (no CUDA device here); CI covers them.

Unrelated observation while testing: the README example
`OptimizationProblem(rosenbrock, x0, p; lb, ub)` errors today, because the
two-argument objective is detected as in-place while `x0` is an `SVector`. It
needs `OptimizationFunction{false}`. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ