### PR TITLE
Release ParallelParticleSwarms 1.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelParticleSwarms"
 uuid = "ab63da0c-63b4-40fa-a3b7-d2cba5be6419"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
## What changed and why

Bumps ParallelParticleSwarms from 1.4.0 to 1.5.0 to release the restored, explicitly documented optimization-cache interface from https://github.com/SciML/ParallelParticleSwarms.jl/pull/127. This is the next consecutive version and follows the minor-bump policy for restored public API in a package at version 1 or later.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — five nonempty testsets, 121 passed / 121 total; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — four nonempty testsets, 95 passed / 95 total; package tests passed. The reinitialization testset contains zero assertions and completed normally.

## Not verified

GPU hardware was not used; the existing tests ran the DiffEqGPU kernels on CPU. The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
