### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,10 +32,10 @@ end
     position = StaticArrays.sacollect(
         T,
         ifelse(
-                abs(prob.u0[i]) > 0,
-                prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
-                rand(eltype(prob.u0))
-            ) for i in 1:dim
+            abs(prob.u0[i]) > 0,
+            prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
+            rand(eltype(prob.u0))
+        ) for i in 1:dim
     )
 
     velocity = zero(T)
@@ -123,9 +123,9 @@ function init_particles!(particles, prob, opt, ::Type{T}) where {T <: SArray}
         gbest_position = StaticArrays.sacollect(
             T,
             ifelse(
-                    abs(prob.u0[i]) > 0, prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
-                    rand(eltype(prob.u0))
-                ) for i in 1:dim
+                abs(prob.u0[i]) > 0, prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
+                rand(eltype(prob.u0))
+            ) for i in 1:dim
         )
     else
         gbest_position = StaticArrays.sacollect(T, uniform_itr(dim, lb, ub))
@@ -151,10 +151,10 @@ function init_particles!(particles, prob, opt, ::Type{T}) where {T <: SArray}
             position = StaticArrays.sacollect(
                 T,
                 ifelse(
-                        abs(prob.u0[i]) > 0,
-                        prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
-                        rand(eltype(prob.u0))
-                    ) for i in 1:dim
+                    abs(prob.u0[i]) > 0,
+                    prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
+                    rand(eltype(prob.u0))
+                ) for i in 1:dim
             )
         else
             @inbounds position = StaticArrays.sacollect(T, positions[j, i] for j in 1:dim)
@@ -198,9 +198,9 @@ function init_particles(prob, opt, ::Type{T}) where {T <: SArray}
         gbest_position = StaticArrays.sacollect(
             T,
             ifelse(
-                    abs(prob.u0[i]) > 0, prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
-                    rand(eltype(prob.u0))
-                ) for i in 1:dim
+                abs(prob.u0[i]) > 0, prob.u0[i] + rand(eltype(prob.u0)) * abs(prob.u0[i]),
+                rand(eltype(prob.u0))
+            ) for i in 1:dim
         )
     else
         gbest_position = StaticArrays.sacollect(T, uniform_itr(dim, lb, ub))
@@ -222,10 +222,10 @@ function init_particles(prob, opt, ::Type{T}) where {T <: SArray}
             @inbounds position = StaticArrays.sacollect(
                 T,
                 ifelse(
-                        abs(prob.u0[j]) > 0,
-                        prob.u0[j] + rand(eltype(prob.u0)) * abs(prob.u0[j]),
-                        rand(eltype(prob.u0))
-                    ) for j in 1:dim
+                    abs(prob.u0[j]) > 0,
+                    prob.u0[j] + rand(eltype(prob.u0)) * abs(prob.u0[j]),
+                    rand(eltype(prob.u0))
+                ) for j in 1:dim
             )
         else
             @inbounds position = StaticArrays.sacollect(T, positions[j, i] for j in 1:dim)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `a6cdd68c9fb5`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/utils.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
CPU 44/44 and QA 44/44 passed; package tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
CPU 44/44 and All 44/44 passed; package tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)