### PR TITLE
Require LatticeRules 0.0.2 (32-bit LatticeRule32)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ SimpleOptimization = "510db2f7-4254-4e34-bbda-04240c91ca8f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+LatticeRules = "0.0.2"
 Adapt = "4.3"
 ADTypes = "1"
 Atomix = "1"
@@ -58,6 +59,7 @@ SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]
+LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -65,4 +67,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["JET", "LinearAlgebra", "SafeTestsets", "Test"]
+test = ["LatticeRules", "JET", "LinearAlgebra", "SafeTestsets", "Test"]


### PR DESCRIPTION
## Summary
Force LatticeRules ≥0.0.2 so QuasiMonteCarlo LatticeRuleSample precompile works on i686 (0.0.1 rejects `typemax(UInt32)+1`-style bounds).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)