### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StaticArrays,SciMLBase,KernelAbstractions"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,54 @@
+using ParallelParticleSwarms, BenchmarkTools
+using StaticArrays, SciMLBase, KernelAbstractions
+
+const SUITE = BenchmarkGroup()
+
+backend = CPU()
+
+# Out-of-place objective on SVector states
+function rosenbrock(x, p)
+    return (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+end
+
+opt_f = OptimizationFunction{false}(rosenbrock)
+x0 = @SVector [0.5f0, 0.5f0]
+lb = @SVector [-5.0f0, -5.0f0]
+ub = @SVector [5.0f0, 5.0f0]
+p = @SVector [1.0f0, 100.0f0]
+prob = OptimizationProblem(opt_f, x0, p; lb = lb, ub = ub)
+
+n_particles = 200
+
+# =============================================================================
+# PSO solves
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+SUITE["solve"]["parallel_pso"] = @benchmarkable solve(
+    $prob, ParallelPSOKernel($n_particles; backend = $backend);
+    maxiters = 100
+)
+SUITE["solve"]["sync_pso"] = @benchmarkable solve(
+    $prob, ParallelSyncPSOKernel($n_particles; backend = $backend);
+    maxiters = 100
+)
+SUITE["solve"]["serial_pso"] = @benchmarkable solve(
+    $prob, SerialPSO($n_particles); maxiters = 100
+)
+
+# Constrained variant
+function conss(x, p)
+    return SVector{2}(-x[1] + 2 * x[2] - 1, x[1]^2 / 4 + x[2]^2 - 1)
+end
+opt_fc = OptimizationFunction{false}(rosenbrock, cons = conss)
+lcons = @SVector [-Inf32, -Inf32]
+ucons = @SVector [0.0f0, 0.0f0]
+prob_c = OptimizationProblem(
+    opt_fc, x0, p; lcons = lcons, ucons = ucons, lb = lb, ub = ub
+)
+
+SUITE["solve"]["constrained"] = @benchmarkable solve(
+    $prob_c, ParallelSyncPSOKernel($n_particles; backend = $backend);
+    maxiters = 100
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~31s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~31s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md